### PR TITLE
Message sending function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 # Ignore Byebug command history file.
 .byebug_history
 user-materials/
+public/uploads/*

--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem "font-awesome-rails"
 gem "devise"
+gem "carrierwave"
+gem "mini_magick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,11 +38,20 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (7.1.4)
     bcrypt (3.1.13)
     bindex (0.8.1)
     builder (3.2.3)
     byebug (11.0.1)
+    carrierwave (2.0.1)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -81,6 +90,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.9.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.13, < 3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
@@ -96,6 +108,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mimemagic (0.3.3)
+    mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -104,6 +118,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (0.6.3)
@@ -138,6 +153,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.14)
+      ffi (~> 1.9)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
     sass (3.7.4)
@@ -190,6 +207,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   font-awesome-rails
@@ -197,6 +215,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,7 +3,7 @@ class MessagesController < ApplicationController
 
   def index
     @message =  Message.new
-    @Messages = @group.messages.includes(:user) 
+    @messages = @group.messages.includes(:user) 
   end
 
   def create
@@ -11,7 +11,7 @@ class MessagesController < ApplicationController
     if @message.save
       redirect_to group_messages_path(@group), notice:  "メッセージが送信されました"
     else
-      @message = @group.messages.includes(:user)
+      @messages = @group.messages.includes(:user)
       flash.now[:alert] = "メッセージを入力してください"
       render :index
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,29 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
-     @group = Group.find(params[:group_id])
+    @message =  Message.new
+    @Messages = @group.messages.includes(:user) 
+  end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice:  "メッセージが送信されました"
+    else
+      @message = @group.messages.includes(:user)
+      flash.now[:alert] = "メッセージを入力してください"
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,11 @@ class Group < ApplicationRecord
   has_many  :users, through: :group_users
   has_many  :messages
   validates :name,  presence: true, uniqueness: true
+  def show_last_message
+    if  (last_message = messages.last).present?
+      last_message.content? ? last_message.content : "画像が投稿されています"  
+    else
+      "メッセージはまだありません。"
+    end  
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   has_many  :group_users
   has_many  :users, through: :group_users
+  has_many  :messages
   validates :name,  presence: true, uniqueness: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,6 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,4 +3,5 @@ class Message < ApplicationRecord
   belongs_to :user
 
   validates :content, presence: true, unless: :image?
+  mount_uploader  :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,49 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+    include CarrierWave::MiniMagick
+
+    process resize_to_fit: [800, 800]
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,3 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = render partial: 'form' {group: @group}
+  = render partial: 'form' 

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,11 @@
+.message
+  .upper-message
+    %p.upper-message__username 
+      = message.user.name
+    %p.upper-message__date 
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  .lower-message
+    - if message.content.present?
+    %p.lower-message__content
+      = message.content
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -6,6 +6,6 @@
       = message.created_at.strftime("%Y/%m/%d %H:%M")
   .lower-message
     - if message.content.present?
-    %p.lower-message__content
-      = message.content
+      %p.lower-message__content
+        = message.content
     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -16,5 +16,5 @@
           %p.group__name 
             = group.name
           %p.group__message 
-            メッセージはまだありません。
+            = group.show_last_message
 

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -14,12 +14,7 @@
             = link_to edit_group_path(@group) do
               Edit
       .messages
-        .message
-          .upper-message
-            %p.upper-message__username Rungo
-            %p.upper-message__date 2019/08/25(sun) 15:49:18
-          .lower-message
-            %p.lower-message__content こんにちは
+        = render partial: 'message', collection: @messages
       .form
         = form_for [@group, @message] do |f|
           .form__message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -21,10 +21,10 @@
           .lower-message
             %p.lower-message__content こんにちは
       .form
-        %form.new_message
+        = form_for [@group, @message] do |f|
           .form__message
-            %input.form__mask{:placeholder => "type a message"}/
-            %label.form__image{:for => "message_image"}
-              %i.fa.fa-picture-o
-              %input#message_image.hidden{:name => "message[image]", :type => "file"}/
-            %input.submit__btn{:input => "", :name => "commit", :type => "submit", :value => "Send"}/
+            = f.text_field :content, class: "form__mask", placeholder: "type a message"
+            = f.label :image, class: "form__image" do
+              = fa_icon 'picture-o', class: "icon"
+              = f.file_field :image, class: "hidden"
+            = f.submit "Send", class: "submit__btn"

--- a/db/migrate/20190906133733_create_messages.rb
+++ b/db/migrate/20190906133733_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string  :content
+      t.string  :image
+      t.references :group, foreign_key: true
+      t.references :user,  foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190903125630) do
+ActiveRecord::Schema.define(version: 20190906133733) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 20190903125630) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -44,4 +55,6 @@ ActiveRecord::Schema.define(version: 20190903125630) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# What
グループメッセージ送信機能の実装と送信した情報をグループユーザが見れるページのメインバーに表示、またサイドバーにグループごとの最新のメッセージを表示させる

# Why
それぞれのグループごとに自分の所属しているグループのメッセージが見えるようにする、また他のグループの最新のメッセージが見えることで、他にもどんなグループがどんなメッセージのやり取りをしているのかわかり、交流のきっかけになる。